### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-report--버그-제보용-.md
+++ b/.github/ISSUE_TEMPLATE/issue-report--버그-제보용-.md
@@ -1,0 +1,18 @@
+---
+name: Issue Report (버그 제보용)
+about: Issue template for non-HY viewers
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# READ BEFORE SUBMITTING ISSUE!
+✅ **Must** include full log and detailed screenshot or video
+✅ Issues with just simple sentences like 'something doesn't work', or 'the game crashes' will be ignored (will be labed as `no info`)
+✅ Please describe the issue as detailed as possible
+✅ Full log file is located in `C:\Users\[username]\Documents\My Games\Binding of Isaac Repentance+`. Keep in mind that if the issue is non-crash issue, the log will be erased as soon as you turned on `isaac-ng.exe`
+✅ Attach one of labels below, which issue the mod comes from
+- [Rep+] Astrobirth (https://steamcommunity.com/sharedfiles/filedetails/?id=3260980911)
+- astro-pockets (https://steamcommunity.com/sharedfiles/filedetails/?id=3460799883)
+- newbie-helper (https://steamcommunity.com/sharedfiles/filedetails/?id=3581362367)


### PR DESCRIPTION
대결모드 외수화에 따라 해외 유저에게서 모드 오류 제보가 등장하기 시작. 스팀 모드 페이지는 댓글이 막혀있기에 엉뚱한 모드 페이지에다가 제보하는 것을 방지하기 위해 해외 유저 전용 양식 추가